### PR TITLE
feature: Dependabot for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    reviewers:
+      - "oap75"
+      - "endersonmaia"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "dependabot"
+    pull-request-branch-name:
+      separator: "/"


### PR DESCRIPTION
/close #31 

This PR uses [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot) to watch the latest github actions changes every week and then create a PR if some version has changed. (assign @oap75 and @endersonmaia to that PR)