### PR TITLE
Feature/remove mnomenic network difinition for localnode

### DIFF
--- a/charts/rollups-node/ci/localnode-values.yaml.tpl
+++ b/charts/rollups-node/ci/localnode-values.yaml.tpl
@@ -1,6 +1,5 @@
 dapp:
   image: docker.io/cartesi/dapp:echo-python-0.16.0-server
-  network: localhost
 
 extraDeploy:
   - apiVersion: v1

--- a/charts/rollups-node/ci/localnode-values.yaml.tpl
+++ b/charts/rollups-node/ci/localnode-values.yaml.tpl
@@ -1,7 +1,5 @@
 dapp:
   image: docker.io/cartesi/dapp:echo-python-0.16.0-server
-  mnemonic:
-    value: "test test test test test test test test test test test junk"
   network: localhost
 
 extraDeploy:

--- a/charts/rollups-node/templates/_helpers.tpl
+++ b/charts/rollups-node/templates/_helpers.tpl
@@ -180,5 +180,10 @@ Return the chainID based on the network
 */}}
 {{- define "dapp.chainID" -}}
 {{- $networkIDs := dict "mainnet" "1" "optimism" "10" "optimism-goerli" "420" "arbitrum" "42161" "arbitrum-goerli" "421613" "localhost" "31337" "sepolia" "11155111" -}}
-{{- get $networkIDs (required "A valid .Values.dapp.network is required" .Values.dapp.network) -}}
+{{- $network := .Values.dapp.network }}
+{{- if .Values.validator.localnode.enabled }}
+  {{- $network = "localhost" }}
+{{- end }}
+{{- $chainID := index $networkIDs $network }}
+{{- $chainID }}
 {{- end -}}

--- a/charts/rollups-node/templates/dispatcher-deployment.yaml
+++ b/charts/rollups-node/templates/dispatcher-deployment.yaml
@@ -97,7 +97,7 @@ spec:
             {{- end }}
           {{- end }}
           volumeMounts:
-            {{- if (or .Values.dapp.mnemonic.value .Values.dapp.mnemonic.secretRef) }}
+            {{- if (or .Values.dapp.mnemonic.value .Values.validator.localnode.enabled .Values.dapp.mnemonic.secretRef) }}
             - name: mnemonic
               mountPath: /var/run/secrets/mnemonic
               readOnly: true
@@ -267,7 +267,7 @@ spec:
             items:
               - key: "dapp.json"
                 path: "dapp.json"
-        {{- if (or .Values.dapp.mnemonic.value .Values.dapp.mnemonic.secretRef) }}
+        {{- if (or .Values.dapp.mnemonic.value .Values.validator.localnode.enabled .Values.dapp.mnemonic.secretRef) }}
         - name: mnemonic
           secret:
             {{- if (or .Values.dapp.mnemonic.value .Values.validator.localnode.enabled) }}

--- a/charts/rollups-node/templates/dispatcher-deployment.yaml
+++ b/charts/rollups-node/templates/dispatcher-deployment.yaml
@@ -56,8 +56,8 @@ spec:
             - --rd-rollups-deployment-file=/opt/cartesi/share/deployments/localhost.json
             - --rd-dapp-deployment-file=/deployments/localhost/dapp.json
             {{- else }}
-            - {{ print "--rd-rollups-deployment-file=/opt/cartesi/share/deployments/" (.Values.dapp.network | replace "-" "_") ".json" | quote }}
-            - {{ print "--rd-dapp-deployment-file=/deployments/" (.Values.dapp.network | replace "-" "_") "/dapp.json" | quote }}
+            - {{ print "--rd-rollups-deployment-file=/opt/cartesi/share/deployments/" (required "A valid .Values.dapp.network is required" .Values.dapp.network | replace "-" "_") ".json" | quote }}
+            - {{ print "--rd-dapp-deployment-file=/deployments/" (required "A valid .Values.dapp.network is required" .Values.dapp.network | replace "-" "_") "/dapp.json" | quote }}
             {{- end }}
             {{- if (or .Values.dapp.mnemonic.value .Values.dapp.mnemonic.secretRef .Values.validator.localnode.enabled) }}
             - {{ print "--auth-mnemonic-file=/var/run/secrets/mnemonic/MNEMONIC" | quote }}

--- a/charts/rollups-node/templates/dispatcher-deployment.yaml
+++ b/charts/rollups-node/templates/dispatcher-deployment.yaml
@@ -52,8 +52,13 @@ spec:
             {{- if .Values.validator.dispatcher.healthCheck.enabled }}
             - {{ print "--http-server-port=" (default .Values.validator.dispatcher.healthCheck.port 8081) | quote }}
             {{- end }}
+            {{- if .Values.validator.localnode.enabled }}
+            - --rd-rollups-deployment-file=/opt/cartesi/share/deployments/localhost.json
+            - --rd-dapp-deployment-file=/deployments/localhost/dapp.json
+            {{- else }}
             - {{ print "--rd-rollups-deployment-file=/opt/cartesi/share/deployments/" (.Values.dapp.network | replace "-" "_") ".json" | quote }}
             - {{ print "--rd-dapp-deployment-file=/deployments/" (.Values.dapp.network | replace "-" "_") "/dapp.json" | quote }}
+            {{- end }}
             {{- if (or .Values.dapp.mnemonic.value .Values.dapp.mnemonic.secretRef .Values.validator.localnode.enabled) }}
             - {{ print "--auth-mnemonic-file=/var/run/secrets/mnemonic/MNEMONIC" | quote }}
             {{- end }}
@@ -62,7 +67,7 @@ spec:
             {{- else }}
             - {{ print "--tx-provider-http-endpoint=" (required "A valid .Values.dapp.httpProvider is required" .Values.dapp.httpProvider) | quote }}
             {{- end }}
-            {{- if .Values.dapp.network }}
+            {{- if (or .Values.dapp.network .Values.validator.localnode.enabled) }}
             - {{ print "--tx-chain-id=" (include "dapp.chainID" .) | quote }}
             {{- end }}
             - {{ print (include "validator.redisConfig" .) | quote }}
@@ -190,7 +195,7 @@ spec:
             {{- else }}
             - {{ print "--dapp-contract-address=" .Values.dapp.contractAddress | quote }}
             {{- end }}
-            {{- if .Values.dapp.network }}
+            {{- if (or .Values.dapp.network .Values.validator.localnode.enabled) }}
             - {{ print "--chain-id=" (include "dapp.chainID" .) | quote }}
             {{- end }}
             - {{ print (include "validator.redisConfig" .) | quote }}

--- a/charts/rollups-node/templates/server-manager-deployment.yaml
+++ b/charts/rollups-node/templates/server-manager-deployment.yaml
@@ -66,7 +66,7 @@ spec:
             {{- if .Values.serverManager.advanceRunner.healthCheck.enabled }}
             - {{ print "--healthcheck-port=" (default 8083 .Values.serverManager.advanceRunner.healthCheck.port) | quote }}
             {{- end }}
-            {{- if .Values.dapp.network }}
+            {{- if (or .Values.dapp.network .Values.validator.localnode.enabled) }}
             - {{ print "--chain-id=" (include "dapp.chainID" .) | quote }}
             {{- end }}
            {{- if .Values.validator.localnode.enabled }}


### PR DESCRIPTION
If `localnode` enabled Then do not need to define  `mnomenic` & `network`.